### PR TITLE
✨ add `minVaultBalance` check, return excess ether to `baseFeeVault`, adjust `gasbackRatioNumerator`

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,0 +1,8 @@
+GasbackTest:testConvertGasback() (gas: 50450)
+GasbackTest:testConvertGasback(uint256,uint256) (runs: 256, μ: 370473, ~: 135584)
+GasbackTest:testConvertGasbackBaseFeeVault() (gas: 24310)
+GasbackTest:testConvertGasbackMaxBaseFee() (gas: 21878)
+GasbackTest:testConvertGasbackMinVaultBalance() (gas: 24154)
+GasbackTest:test__codesize() (gas: 8178)
+SoladyTest:test__codesize() (gas: 4099)
+TestPlus:test__codesize() (gas: 393)

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ wake-coverage.cov
 # Create2 build files
 .tmp
 create2
+
+# Coverage report
+report

--- a/src/Gasback.sol
+++ b/src/Gasback.sol
@@ -152,14 +152,16 @@ contract Gasback {
         // If the contract has insufficient ETH, try to pull from the base fee vault.
         if (ethToGive > address(this).balance) {
             address vault = $.baseFeeVault;
-            uint256 requiredVaultBalance = (ethToGive - address(this).balance) + $.minVaultBalance;
+            uint256 minBalance = $.minVaultBalance;
             /// @solidity memory-safe-assembly
             assembly {
                 if extcodesize(vault) {
                     // If the vault has insufficient ETH, revert.
-                    if lt(balance(vault), requiredVaultBalance) { revert(0x00, 0x00) }
+                    if lt(balance(vault), add(sub(ethToGive, balance(address())), minBalance)) { revert(0x00, 0x00) }
                     mstore(0x00, 0x3ccfd60b) // `withdraw()`.
                     pop(call(gas(), vault, 0, 0x1c, 0x04, 0x00, 0x00))
+                    // Return extra ETH to vault.
+                    
                 }
             }
         }

--- a/src/Gasback.sol
+++ b/src/Gasback.sol
@@ -161,7 +161,17 @@ contract Gasback {
                         mstore(0x00, 0x3ccfd60b) // `withdraw()`.
                         pop(call(gas(), vault, 0, 0x1c, 0x04, 0x00, 0x00))
                         // Return extra ETH to vault.
-                        pop(call(gas(), vault, sub(balance(address()), ethToGive), 0x00, 0x00, 0x00, 0x00))
+                        pop(
+                            call(
+                                gas(),
+                                vault,
+                                sub(balance(address()), ethToGive),
+                                0x00,
+                                0x00,
+                                0x00,
+                                0x00
+                            )
+                        )
                     }
                 }
             }

--- a/src/Gasback.sol
+++ b/src/Gasback.sol
@@ -150,6 +150,7 @@ contract Gasback {
             /// @solidity memory-safe-assembly
             assembly {
                 if extcodesize(vault) {
+                    // If the vault has insufficient ETH, revert.
                     if lt(balance(vault), minVaultBalance) { revert(0x00, 0x00) }
                     mstore(0x00, 0x3ccfd60b) // `withdraw()`.
                     pop(call(gas(), vault, 0, 0x1c, 0x04, 0x00, 0x00))

--- a/test/Gasback.t.sol
+++ b/test/Gasback.t.sol
@@ -21,7 +21,7 @@ contract GasbackTest is SoladyTest {
         vm.prank(pranker);
         (bool success,) = address(gasback).call(abi.encode(gasToBurn));
         assertTrue(success);
-        assertEq(pranker.balance, gasToBurn * baseFee * 0.9 ether / 1 ether);
+        assertEq(pranker.balance, gasToBurn * baseFee * 0.8 ether / 1 ether);
     }
 
     function testConvertGasback() public {

--- a/test/Gasback.t.sol
+++ b/test/Gasback.t.sol
@@ -19,7 +19,7 @@ contract GasbackTest is SoladyTest {
         assertEq(pranker.balance, 0);
         vm.fee(baseFee);
         vm.prank(pranker);
-        (bool success, ) = address(gasback).call(abi.encode(gasToBurn));
+        (bool success,) = address(gasback).call(abi.encode(gasToBurn));
         assertTrue(success);
         assertEq(pranker.balance, (gasToBurn * baseFee * 0.8 ether) / 1 ether);
     }
@@ -40,7 +40,7 @@ contract GasbackTest is SoladyTest {
         address pranker = address(111);
         assertEq(pranker.balance, 0);
         vm.prank(pranker);
-        (bool success, ) = address(gasback).call(abi.encode(gasToBurn));
+        (bool success,) = address(gasback).call(abi.encode(gasToBurn));
         assertTrue(success);
         assertEq(pranker.balance, 0);
     }
@@ -55,7 +55,7 @@ contract GasbackTest is SoladyTest {
         address pranker = address(111);
         assertEq(pranker.balance, 0);
         vm.prank(pranker);
-        (bool success, ) = address(gasback).call(abi.encode(gasToBurn));
+        (bool success,) = address(gasback).call(abi.encode(gasToBurn));
         assertTrue(success);
         assertEq(pranker.balance, 0);
     }
@@ -71,7 +71,7 @@ contract GasbackTest is SoladyTest {
         address pranker = address(111);
         assertEq(pranker.balance, 0);
         vm.prank(pranker);
-        (bool success, ) = address(gasback).call(abi.encode(gasToBurn));
+        (bool success,) = address(gasback).call(abi.encode(gasToBurn));
         assertTrue(success);
         assertEq(pranker.balance, 0);
     }


### PR DESCRIPTION
## Description

Adding a balance check before pulling from the `baseFeeVault`, and returning any excess ether.

Reasoning: The vanilla OP sequencer can occasionally underestimate the L1 Fee. When this happens, funds from the `baseFeeVault` are used to cover the deficit.

Proposed solution: Maintain a minimum balance in the `baseFeeVault` to cover any deficits (The exact minimum balance depends on the chain)

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
