### PR TITLE
✨ add `accruedRecipient` and `withdrawAccruedToAccruedRecipient` function to allow permissionless withdrawals

### DIFF
--- a/src/Gasback.sol
+++ b/src/Gasback.sol
@@ -34,6 +34,8 @@ contract Gasback {
         uint256 minVaultBalance;
         // The amount of ETH accrued by taking a cut from the gas burned.
         uint256 accrued;
+        // The recipient of the accrued ETH.
+        address accruedRecipient;
         // A mapping of addresses authorized to withdraw the accrued ETH.
         mapping(address => bool) accuralWithdrawers;
     }
@@ -58,6 +60,7 @@ contract Gasback {
         $.gasbackMaxBaseFee = type(uint256).max;
         $.baseFeeVault = 0x4200000000000000000000000000000000000019;
         $.minVaultBalance = 0.42 ether;
+        $.accruedRecipient = 0x4200000000000000000000000000000000000019;
     }
 
     /*«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-*/
@@ -117,6 +120,25 @@ contract Gasback {
         returns (bool)
     {
         _getGasbackStorage().accuralWithdrawers[addr] = authorized;
+        return true;
+    }
+
+    /// @dev Withdraws from the accrued amount to the accrued recipient.
+    function withdrawAccruedToAccruedRecipient(uint256 amount) public virtual returns (bool) {
+        // Checked math prevents underflow.
+        _getGasbackStorage().accrued -= amount;
+
+        address accruedRecipient = _getGasbackStorage().accruedRecipient;
+        /// @solidity memory-safe-assembly
+        assembly {
+            if iszero(call(gas(), accruedRecipient, amount, 0x00, 0x00, 0x00, 0x00)) { revert(0x00, 0x00) }
+        }
+        return true;
+    }
+
+    /// @dev Sets the accrued recipient.
+    function setAccruedRecipient(address value) public onlySystemOrThis returns (bool) {
+        _getGasbackStorage().accruedRecipient = value;
         return true;
     }
 

--- a/test/Gasback.t.sol
+++ b/test/Gasback.t.sol
@@ -75,4 +75,30 @@ contract GasbackTest is SoladyTest {
         assertTrue(success);
         assertEq(pranker.balance, 0);
     }
+
+    function testConvertGasbackWithAccruedToAccruedRecipient() public {
+        address system = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
+        vm.prank(system);
+        gasback.setAccruedRecipient(address(42));
+
+        uint256 baseFee = 1 ether;
+        uint256 gasToBurn = 333;
+
+        address pranker = address(111);
+        vm.fee(baseFee);
+        vm.deal(pranker, 1000 ether);
+ 
+        vm.prank(pranker);
+        (bool success,) = address(gasback).call(abi.encode(gasToBurn));
+        assertTrue(success);
+
+        uint256 accrued = gasback.accrued();
+
+        assertNotEq(accrued, 0);
+
+        vm.prank(pranker);
+        gasback.withdrawAccruedToAccruedRecipient(accrued);
+
+        assertEq(address(42).balance, accrued);
+    }
 }


### PR DESCRIPTION
## Description

adding a recipient address to send accrued ETH to, allowing anyone to call the withdraw function

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Ran `forge fmt`?
- [ ] Ran `forge snapshot`?
- [ ] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
